### PR TITLE
Require issue openers to select a template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
 blank_issues_enabled: false
+contact_links:
+  - name: Planning Center Support
+    url: https://support.planningcenteronline.com
+    about: Not a developer? Get general Planning Center help from our support team.


### PR DESCRIPTION
Let's make it a little harder for people to ignore our issue templates. 

https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser