### PR TITLE
fix(BatchVertex): update batch commit doc

### DIFF
--- a/guides/giving_donations_integration.md
+++ b/guides/giving_donations_integration.md
@@ -55,9 +55,9 @@ When a `Batch` is committed, all of the `Donation`'s within it are also marked a
 With all of that in mind, you can use `Batch`es in one of two ways:
 
 1. Create an uncommitted `Batch`, add `Donation`s to it, then commit the `Batch`.
-2. Create a `Batch`, commit it, then add `Donation`s to it.
+2. Create a `Batch` with a least one donation, commit it, then add more `Donation`s to it.
 
-In both cases, the end result is the same. The main difference in terms of _when_ the `Batch` is committed makes a difference in that route #2 does not provide you (or Giving admins) the opportunity to fix any mistakes before changes are logged and `Donation`s are made visible to donors.
+In both cases, the end result is the same. The main difference is that option #2 does not provide you/other admins the opportunity to fix any mistakes before changes are logged and `Donation`s are made visible to donors. Any `Donation`s added to a committed `Batch` will automatically be committed as well. Note, batches can't be committed until they have at least one donation.
 
 Whichever route you decide to take, it's helpful to make use of the `Batch`'s `description` to help differentiate these groupings from each other and from other `Batch`es that the Giving admins might be creating on their own.
 


### PR DESCRIPTION
[It has been brought to our attention by an API user that the docs for BatchVertex contain an error.](https://github.com/planningcenter/developers/issues/1074) These docs describe how to use Batches but neglect to acknowledge batch policy validation that states a batch must contain at least one donation in order to be committed. Let's explicitly add this to the docs to avoid confusion.