### PR TITLE
Update `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @planningcenter/engineering-leads
+* @planningcenter/api


### PR DESCRIPTION
The API team should be the owner, not the (no longer existing) ELs.