### PR TITLE
Route CI installs through npm-quarantine-proxy

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -4,6 +4,11 @@ on:
   issues:
     types: [opened]
 
+env:
+  NPM_CONFIG_REGISTRY: ${{ secrets.NPM_CONFIG_REGISTRY }}
+  YARN_NPM_REGISTRY_SERVER: ${{ secrets.YARN_NPM_REGISTRY_SERVER }}
+  BUN_CONFIG_REGISTRY: ${{ secrets.BUN_CONFIG_REGISTRY }}
+
 jobs:
   label-product:
     name: Auto-label product
@@ -19,6 +24,7 @@ jobs:
         with:
           node-version: "20"
           cache: "npm"
+          registry-url: ${{ secrets.NPM_CONFIG_REGISTRY }}
 
       - name: Install dependencies
         run: npm ci
@@ -45,6 +51,7 @@ jobs:
         with:
           node-version: "20"
           cache: "npm"
+          registry-url: ${{ secrets.NPM_CONFIG_REGISTRY }}
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Why this PR exists

We're routing CI npm/yarn/bun installs through our `npm-quarantine-proxy` so that any workflow run pulls from our 14-day-cooldown proxy instead of public npm. This is one of the open threads on [re-enabling GitHub Actions](https://pco.slack.com/archives/C0B2YGXUFJP) after the 2026-05-11 supply-chain incident.

The org-level Actions secrets are already set (`NPM_CONFIG_REGISTRY`, `YARN_NPM_REGISTRY_SERVER`, `BUN_CONFIG_REGISTRY`). GitHub doesn't auto-inject them into workflow runtime — each workflow has to reference them explicitly. This PR adds those references.

## What this PR does

- Adds a workflow-level `env:` block to every workflow that installs npm/yarn/bun packages, referencing the three org secrets.
- Where the workflow uses `actions/setup-node`, also adds `registry-url:` so `.npmrc` gets generated for npm + yarn 1.

## This is a bulk fix

I'm opening ~79 of these across the org. The change is mechanical and uniform. **Apply local judgment** — if your repo has a non-obvious reason this would break (custom runners, alternate registries, special handling), close this PR and let me know. Otherwise treat as a normal review.

## Ownership

Assigned to you via CODEOWNERS. **You own it from here** — review, adjust if needed, merge. If you're not the right person, please reassign rather than ignoring.
