### PR TITLE
Use NPM_QUARANTINE_REGISTRY for Actions secrets

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -5,9 +5,9 @@ on:
     types: [opened]
 
 env:
-  NPM_CONFIG_REGISTRY: ${{ secrets.NPM_CONFIG_REGISTRY }}
-  YARN_NPM_REGISTRY_SERVER: ${{ secrets.YARN_NPM_REGISTRY_SERVER }}
-  BUN_CONFIG_REGISTRY: ${{ secrets.BUN_CONFIG_REGISTRY }}
+  NPM_CONFIG_REGISTRY: ${{ secrets.NPM_QUARANTINE_REGISTRY }}
+  YARN_NPM_REGISTRY_SERVER: ${{ secrets.NPM_QUARANTINE_REGISTRY }}
+  BUN_CONFIG_REGISTRY: ${{ secrets.NPM_QUARANTINE_REGISTRY }}
 
 jobs:
   label-product:
@@ -24,7 +24,7 @@ jobs:
         with:
           node-version: "20"
           cache: "npm"
-          registry-url: ${{ secrets.NPM_CONFIG_REGISTRY }}
+          registry-url: ${{ secrets.NPM_QUARANTINE_REGISTRY }}
 
       - name: Install dependencies
         run: npm ci
@@ -51,7 +51,7 @@ jobs:
         with:
           node-version: "20"
           cache: "npm"
-          registry-url: ${{ secrets.NPM_CONFIG_REGISTRY }}
+          registry-url: ${{ secrets.NPM_QUARANTINE_REGISTRY }}
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION


This Pull Request is a simple rename. It replaces the 3 secrets that were introduced in https://github.com/planningcenter/developers/pull/1471 as a rapid response to [#incident-sev0-2026-05-11-npm-supply-chain-attack](https://pco.slack.com/archives/C0B2YGXUFJP) with a single `NPM_QUARANTINE_REGISTRY` secret. These 4 secrets all hold the same value, so there should be no behavior changes.

I'm doing this to minimize the surface area of what needs to change if we ever need to rotate the value of our npm quarantine registry's URL.

| Before | After |
| --- | --- |
| `secrets.NPM_CONFIG_REGISTRY` | `secrets.NPM_QUARANTINE_REGISTRY` |
| `secrets.YARN_NPM_REGISTRY_SERVER` | `secrets.NPM_QUARANTINE_REGISTRY` |
| `secrets.BUN_CONFIG_REGISTRY` | `secrets.NPM_QUARANTINE_REGISTRY` |

The environment variable names stay because npm/yarn/bun read those directly. Only the source secret is being consolidated. This distinction in names helps reinforce the reality that GitHub Action secrets are not automatically made available as environment variables.

The old secrets will be deleted after I've confirmed they're no longer referenced anywhere in the org, using this GitHub CLI script:

```bash
for s in NPM_CONFIG_REGISTRY YARN_NPM_REGISTRY_SERVER BUN_CONFIG_REGISTRY; do
  count=$(gh search code "secrets.$s org:planningcenter" --limit 1000 --json repository | jq length)
  echo "$s: $count references"
done
```

### While you're here

The workflow-level `env:` block introduced during the incident response may not even be necessary anymore. Especially with the propagation of `.npmrc` and `.yarnrc.yml` files.

I stopped short of removing the environment variables because I don't know enough about each workflow's local needs to make the call in aggregate. Feel free to add onto this PR by removing them completely if it helps keep your repo and workflows tidy.
